### PR TITLE
remove hack around require puppet_blacksmith/rake_tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,13 +15,7 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppet-syntax/tasks/puppet-syntax'
-
-# These two gems aren't always present, for instance
-# on Travis with --without development
-begin
-  require 'puppet_blacksmith/rake_tasks'
-rescue LoadError
-end
+require 'puppet_blacksmith/rake_tasks'
 
 PuppetLint.configuration.relative = true
 PuppetLint.configuration.send("disable_80chars")


### PR DESCRIPTION
our gemfile has moved puppet-blacksmith to the :test group so this
exception handling around requiring puppet_blacksmith is no longer
necessary.